### PR TITLE
fix use of (cloudbees) builder templates with conditional buildstep

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/lister/DefaultBuilderDescriptorLister.java
+++ b/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/lister/DefaultBuilderDescriptorLister.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.conditionalbuildstep.lister;
 
 import hudson.Extension;
+import hudson.Functions;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
@@ -49,10 +50,11 @@ public class DefaultBuilderDescriptorLister implements BuilderDescriptorLister {
 	}
 
 	public List<? extends Descriptor<? extends BuildStep>> getAllowedBuilders(final AbstractProject<?, ?> project) {
-		final List<BuildStepDescriptor<? extends Builder>> builders = new ArrayList<BuildStepDescriptor<? extends Builder>>();
+		final List<Descriptor<? extends Builder>> builders = new ArrayList<Descriptor<? extends Builder>>();
 		if (project == null)
 			return builders;
-        for (Descriptor<Builder> descriptor : Builder.all()) {
+
+        for (Descriptor<Builder> descriptor : Functions.getBuilderDescriptors(project)) {
             if (descriptor instanceof SingleConditionalBuilder.SingleConditionalBuilderDescriptor) {
 				continue;
 			}
@@ -62,26 +64,13 @@ public class DefaultBuilderDescriptorLister implements BuilderDescriptorLister {
 			if (descriptor instanceof BuilderChain.DescriptorImpl) {
                 continue;
             }
-			if (!(descriptor instanceof BuildStepDescriptor)) {
-				continue;
-			}
-			BuildStepDescriptor<? extends Builder> buildStepDescriptor = (BuildStepDescriptor) descriptor;
-			if (buildStepDescriptor.isApplicable(project.getClass()) && hasDbc(buildStepDescriptor.clazz))
-				builders.add(buildStepDescriptor);
+        	builders.add(descriptor);
 		}
 		return builders;
 	}
 
 	public DescriptorImpl getDescriptor() {
 		return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class);
-	}
-
-	private boolean hasDbc(final Class<?> clazz) {
-		for (Constructor<?> constructor : clazz.getConstructors()) {
-			if (constructor.isAnnotationPresent(DataBoundConstructor.class))
-				return true;
-		}
-		return false;
 	}
 
 	@Extension


### PR DESCRIPTION
Use Functions.getBuildDescriptor to filter descriptor to match the project - logic there is more advanced and supports pre-1.150 plugins
Remove check for @DataBoundConstructor. descriptor may use another strategy to create instance, overriding newInstance(). I looked into git history for the plugin but this code was create in one single commit, so can't tell why this check was introduced
