### PR TITLE
Fixing Jenkins dependency graph generation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/BuilderChain.java
+++ b/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/BuilderChain.java
@@ -28,9 +28,7 @@ import hudson.Launcher;
 import hudson.matrix.MatrixAggregatable;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
+import hudson.model.*;
 import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
@@ -45,7 +43,7 @@ import java.util.List;
  * @author Dominik Bartholdi (imod)
  * 
  */
-public class BuilderChain extends Builder {
+public class BuilderChain extends Builder implements DependecyDeclarer {
 
     private final List<Builder> conditionalbuilders;
 
@@ -80,6 +78,15 @@ public class BuilderChain extends Builder {
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
+    }
+
+    public void buildDependencyGraph(AbstractProject owner, DependencyGraph graph) {
+        for (Object o : conditionalbuilders) {
+            if (o instanceof DependecyDeclarer) {
+                DependecyDeclarer dd = (DependecyDeclarer) o;
+                dd.buildDependencyGraph(owner,graph);
+            }
+        }
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/ConditionalBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/ConditionalBuilder.java
@@ -26,11 +26,7 @@ package org.jenkinsci.plugins.conditionalbuildstep;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import hudson.model.*;
 import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
@@ -56,7 +52,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Dominik Bartholdi (imod)
  * @author Chris Johnson (cjo9900)
  */
-public class ConditionalBuilder extends Builder {
+public class ConditionalBuilder extends Builder implements DependecyDeclarer {
     private static Logger log = Logger.getLogger(ConditionalBuilder.class.getName());
 
     // retaining backward compatibility
@@ -126,6 +122,15 @@ public class ConditionalBuilder extends Builder {
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
+    }
+
+    public void buildDependencyGraph(AbstractProject owner, DependencyGraph graph) {
+        for (Object o : conditionalbuilders) {
+            if (o instanceof DependecyDeclarer) {
+                DependecyDeclarer dd = (DependecyDeclarer) o;
+                dd.buildDependencyGraph(owner,graph);
+            }
+        }
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/singlestep/SingleConditionalBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/singlestep/SingleConditionalBuilder.java
@@ -27,11 +27,7 @@ package org.jenkinsci.plugins.conditionalbuildstep.singlestep;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import hudson.model.*;
 import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -58,7 +54,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Anthony Robinson
  * @author Dominik Bartholdi (imod)
  */
-public class SingleConditionalBuilder extends Builder {
+public class SingleConditionalBuilder extends Builder implements DependecyDeclarer {
 
     public static final String PROMOTION_JOB_TYPE = "hudson.plugins.promoted_builds.PromotionProcess";
 
@@ -102,6 +98,12 @@ public class SingleConditionalBuilder extends Builder {
     @Override
     public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
         return runner.perform(condition, buildStep, build, launcher, listener);
+    }
+
+    public void buildDependencyGraph(AbstractProject abstractProject, DependencyGraph dependencyGraph) {
+        if(buildStep instanceof DependecyDeclarer){
+            ((DependecyDeclarer) buildStep).buildDependencyGraph(abstractProject, dependencyGraph);
+        }
     }
 
     @Extension(ordinal = Integer.MAX_VALUE - 500)


### PR DESCRIPTION
To be Jenkins project's dependency graph well built, builders which
wraps build triggers must implement DependencyDeclarer interface. If
conditional build step wraps build trigger - it should populate
downstream project's dependency graph
