### PR TITLE
[JENKINS-35526] Update to DependencyDeclarer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/singlestep/SingleConditionalBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/singlestep/SingleConditionalBuilder.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import jenkins.model.DependencyDeclarer;
 import net.sf.json.JSONObject;
 
 import org.jenkins_ci.plugins.run_condition.RunCondition;
@@ -110,8 +111,9 @@ public class SingleConditionalBuilder extends Builder implements DependecyDeclar
     
     public void buildDependencyGraph(AbstractProject project, DependencyGraph graph) {
         if(buildStep != null) {
-            if(buildStep instanceof DependecyDeclarer) {
-                ((DependecyDeclarer)buildStep).buildDependencyGraph(project, graph);
+            if(buildStep instanceof DependencyDeclarer) {
+                DependencyDeclarer dependencyDeclarer = (DependencyDeclarer) buildStep;
+                dependencyDeclarer.buildDependencyGraph(project, graph);
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/singlestep/SingleConditionalBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/singlestep/SingleConditionalBuilder.java
@@ -63,7 +63,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Anthony Robinson
  * @author Dominik Bartholdi (imod)
  */
-public class SingleConditionalBuilder extends Builder implements DependecyDeclarer {
+public class SingleConditionalBuilder extends Builder implements DependencyDeclarer {
 
     public static final String PROMOTION_JOB_TYPE = "hudson.plugins.promoted_builds.PromotionProcess";
 


### PR DESCRIPTION
Basically, I believe this stacktrace is saying that when the maven-plugin is doing [getParent().getPublishers()](https://github.com/jenkinsci/maven-plugin/blob/9c5eb51dda735450a6cc7a59201efe2cd795625a/src/main/java/hudson/maven/MavenModule.java#L675) in Runtime is getting `ClassCastException` because there is something on the list that is not a `Publisher`. I believe the problem is in the [conditional-buildstep-plugin](https://github.com/jenkinsci/conditional-buildstep-plugin/blob/a906535e3d680c7c8ca5d79a3bde9c80d56e9564/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/singlestep/SingleConditionalBuilder.java#L113) which is doing a cast to `DependecyDeclarer ` - which is deprecated - and `DependencyDeclarer` needs to be used instead.

```
udson.util.HudsonFailedToLoad: org.jvnet.hudson.reactor.ReactorException: java.lang.ClassCastException: org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder cannot be cast to hudson.tasks.Publisher 
at hudson.WebAppMain$3.run(WebAppMain.java:237) 
Caused by: org.jvnet.hudson.reactor.ReactorException: java.lang.ClassCastException: org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder cannot be cast to hudson.tasks.Publisher 
at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:269) 
at jenkins.InitReactorRunner.run(InitReactorRunner.java:44) 
at jenkins.model.Jenkins.executeReactor(Jenkins.java:935) 
at jenkins.model.Jenkins.<init>(Jenkins.java:816) 
at hudson.model.Hudson.<init>(Hudson.java:83) 
at hudson.model.Hudson.<init>(Hudson.java:79) 
at hudson.WebAppMain$3.run(WebAppMain.java:225) 
Caused by: java.lang.ClassCastException: org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder cannot be cast to hudson.tasks.Publisher 
at hudson.maven.MavenModule.getDependencyRelevancy(MavenModule.java:675) 
at hudson.maven.MavenModule.chooseMoreRelevantModule(MavenModule.java:632) 
at hudson.maven.MavenModule.buildDependencyGraph(MavenModule.java:515) 
at hudson.model.DependencyGraph.build(DependencyGraph.java:95) 
at jenkins.model.Jenkins.rebuildDependencyGraph(Jenkins.java:3816) 
at jenkins.model.Jenkins$20.run(Jenkins.java:2742) 
at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169) 
at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282) 
at jenkins.model.Jenkins$8.runTask(Jenkins.java:924) 
at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210) 
at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117) 
at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) 
at java.lang.Thread.run(Unknown Source)
```

@reviewbybees 