### PR TITLE
Update matrix-project version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>matrix-project</artifactId>
-			<version>1.0-beta-1</version>
+			<version>1.7.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- Update to current version because beta version no longer seems to be available from http://updates.jenkins-ci.org/download/plugins/matrix-project/
