### PR TITLE
[JENKINS-43887] Update parent POM to 2.X.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<jenkins.version>1.580.1</jenkins.version>
 		<java.level>6</java.level>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.580.1</version>
+		<version>2.26</version>
 	</parent>
 
 	<artifactId>conditional-buildstep</artifactId>
@@ -26,6 +26,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+		<jenkins.version>1.580.1</jenkins.version>
+		<java.level>6</java.level>
 	</properties>
 	<licenses>
 		<license>
@@ -63,12 +65,18 @@
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
-			<version>2.8</version>
+			<version>2.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>matrix-project</artifactId>
-			<version>1.0-beta-1</version>
+			<version>1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>mailer</artifactId>
+			<version>1.17</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/ConditionalBuildStepHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/conditionalbuildstep/ConditionalBuildStepHelper.java
@@ -111,7 +111,12 @@ public class ConditionalBuildStepHelper {
      * @return
      */
     public static boolean isMavenPluginInstalled() {
-        final hudson.Plugin plugin = Jenkins.getInstance().getPlugin("maven-plugin");
-        return plugin != null ? plugin.getWrapper().isActive() : false;
+        Jenkins j = Jenkins.getInstance();
+        if (j != null) {
+            final hudson.Plugin plugin = j.getPlugin("maven-plugin");
+            return plugin != null ? plugin.getWrapper().isActive() : false;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   A buildstep wrapping any number of other buildsteps, controlling their execution based on a defined condition (e.g. BuildParameter). 
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/conditionalbuildstep/ConditionalBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/conditionalbuildstep/ConditionalBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 	<f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/conditionalbuildstep/LegacyBuildstepCondition/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/conditionalbuildstep/LegacyBuildstepCondition/help.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
 	Used to retain backward compatibility... please use the 'Boolean condition'
     The resolved value has to be <code>true</code> or <code>false</code> (where everything else then <code>true</code> is handled as <code>false</code>, case ignored).<br />

--- a/src/test/java/org/jenkinsci/plugins/conditionalbuildstep/ConfigFileBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/conditionalbuildstep/ConfigFileBuildWrapperTest.java
@@ -21,7 +21,8 @@ public class ConfigFileBuildWrapperTest {
     @Test
     public void conditionalBuildersInMavenProjectMustBeResolvable() throws Exception {
 
-        final MavenModuleSet p = j.createMavenProject("mvn");
+        final MavenModuleSet p = j.createProject(MavenModuleSet.class, "mvn");
+        p.setRunHeadless(true);
 
         ConditionalBuilder cBuilder = new ConditionalBuilder(new BooleanCondition("true"), new BuildStepRunner.Run());
         Shell shell = new Shell("ls");


### PR DESCRIPTION
[JENKINS-43887](https://issues.jenkins-ci.org/browse/JENKINS-43887)

- Uses 2.26 parent POM.
- Bump some dependencies.
- Fix tests.
- Fix Findbugs errors.

@reviewbybees @jglick @kwhetstone @andresrc @imod @bap2000 