### PR TITLE
Fix link from plugins site to GitHub source code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<scm>
 		<connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
-		<url>https://github.com/jenkinsci/${gitHubRepo}</url>
+		<url>https://github.com/${gitHubRepo}</url>
 	  <tag>${scmTag}</tag>
   </scm>
 	<properties>


### PR DESCRIPTION
The "GitHub" link at https://plugins.jenkins.io/conditional-buildstep/ is broken.  It includes an extra "jenkinsci" in the URL