### PR TITLE
Make dep on `maven-plugin` be `optional`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
 			<version>3.7</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
05e70affeccdf024dd8a388de5b23a9d33f10c21 actually guarded the runtime code with a check whether the dep was present or not, but forgot to actually mark it `optional`.
