### PR TITLE
Use https:// protocol in SCM URL, not git:// protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<description>A buildstep wrapping any number of other buildsteps, controlling their execution based on a defined condition.</description>
 	<url>https://plugins.jenkins.io/conditional-buildstep/</url>
 	<scm>
-		<connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
 		<url>https://github.com/${gitHubRepo}</url>
 	  <tag>${scmTag}</tag>


### PR DESCRIPTION
GitHub has deprecated the git:// protocol and requires either https:// or ssh://

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
