### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<spotbugs.effort>Max</spotbugs.effort>
 		<spotbugs.threshold>Low</spotbugs.threshold>
 		<spotbugs.excludeFilterFile>${project.basedir}/src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
-		<jenkins.version>2.361.4</jenkins.version>
+		<jenkins.version>2.387.3</jenkins.version>
 	</properties>
 	<licenses>
 		<license>
@@ -62,12 +62,10 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>run-condition</artifactId>
-			<version>1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
-			<version>3.16</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -95,8 +93,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.361.x</artifactId>
-				<version>2102.v854b_fec19c92</version>
+				<artifactId>bom-2.387.x</artifactId>
+				<version>2329.v078520e55c19</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

Simplifies dependency version management because the newer releases of the plugin bill of materials now include the maven plugin and the run-condition plugin.

### Testing done

Confirmed that tests run successfully without the versions explicitly declared in the pom.

Supersedes:

* #76 
* #69 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
