### PR TITLE
Reduce Jenkinsfile diffs to archetype

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,10 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
-    [platform: 'linux',   jdk: '17'],
-    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
-    [platform: 'windows', jdk: '11']
-  ]
-)
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])


### PR DESCRIPTION
## Reduce Jenkinsfile diffs to archetype

Use the Jenkins plugin archetype as much as possible as we can so that the differences to the archetype are clear and intentionally used.

Tests with Java 21 on Linux and Java 17 on Windows.  Accepts that tests on Java 11 are redundant since we've not detected relevant issues that are specific to Java 11.

### Testing done

Confirmed that tests pass on Linux with Java 17 and Java 21.

Rely on ci.jenkins.io to test Windows.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
